### PR TITLE
INFRA-11960 preshared key into secrets manager

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -139,8 +139,8 @@ resource "aws_vpn_connection" "tunnel" {
   static_routes_only  = var.vpn_connection_static_routes_only
   enable_acceleration = var.vpn_connection_enable_acceleration
 
-  tunnel1_inside_cidr = var.tunnel1_inside_cidr
-  tunnel2_inside_cidr = var.tunnel2_inside_cidr
+  tunnel1_inside_cidr   = var.tunnel1_inside_cidr
+  tunnel2_inside_cidr   = var.tunnel2_inside_cidr
   preshared_key_storage = "SecretsManager"
 
   tunnel1_phase1_dh_group_numbers = var.tunnel1_phase1_dh_group_numbers

--- a/main.tf
+++ b/main.tf
@@ -141,6 +141,7 @@ resource "aws_vpn_connection" "tunnel" {
 
   tunnel1_inside_cidr = var.tunnel1_inside_cidr
   tunnel2_inside_cidr = var.tunnel2_inside_cidr
+  preshared_key_storage = "SecretsManager"
 
   tunnel1_phase1_dh_group_numbers = var.tunnel1_phase1_dh_group_numbers
   tunnel2_phase1_dh_group_numbers = var.tunnel2_phase1_dh_group_numbers
@@ -257,6 +258,7 @@ resource "aws_vpn_connection" "preshared" {
 
   tunnel1_preshared_key = var.tunnel1_preshared_key
   tunnel2_preshared_key = var.tunnel2_preshared_key
+  preshared_key_storage = "SecretsManager"
 
   tunnel1_phase1_dh_group_numbers = var.tunnel1_phase1_dh_group_numbers
   tunnel2_phase1_dh_group_numbers = var.tunnel2_phase1_dh_group_numbers


### PR DESCRIPTION
This update enables the AWS VPN service to store the pre-shared key (PSK) in AWS Secrets Manager and manage it automatically. If needed, the PSK value can still be manually specified by updating the managed secret in Secrets Manager.